### PR TITLE
WFC-11 Update EmbeddedCacheManagerGroup.getName() to use name of delegate group

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,11 @@
 		<version.net.jcip>1.0</version.net.jcip>
 
 		<!-- Compile dependency versions -->
-		<version.org.infinispan>14.0.32.Final</version.org.infinispan>
+		<version.org.infinispan>14.0.33.Final</version.org.infinispan>
 		<version.org.jboss.logging>3.6.1.Final</version.org.jboss.logging>
 		<version.org.jboss.marshalling>2.2.1.Final</version.org.jboss.marshalling>
 		<version.org.jboss.threads>3.6.1.Final</version.org.jboss.threads>
-		<version.org.jgroups>5.2.28.Final</version.org.jgroups>
+		<version.org.jgroups>5.2.29.Final</version.org.jgroups>
 		<version.org.kohsuke.metainf-services>1.11</version.org.kohsuke.metainf-services>
 		<version.org.wildfly.common>1.7.0.Final</version.org.wildfly.common>
 

--- a/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/EmbeddedCacheManagerGroup.java
+++ b/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/EmbeddedCacheManagerGroup.java
@@ -25,14 +25,12 @@ import org.wildfly.clustering.server.group.GroupMember;
  */
 public class EmbeddedCacheManagerGroup<A extends Comparable<A>, M extends GroupMember<A>> implements CacheContainerGroup {
 
-	private final String name;
 	private final Group<A, M> group;
 	private final Function<M, CacheContainerGroupMember> wrapper;
 	private final CacheContainerGroupMemberFactory factory;
 	private final CacheContainerGroupMember localMember;
 
 	public EmbeddedCacheManagerGroup(EmbeddedCacheManagerGroupConfiguration<A, M> configuration) {
-		this.name = configuration.getCacheContainer().getCacheManagerConfiguration().cacheManagerName();
 		this.group = configuration.getGroup();
 		this.factory = new EmbeddedCacheManagerGroupMemberFactory(configuration);
 		this.wrapper = configuration.getAddressWrapper().<M>compose(GroupMember::getAddress).andThen(this.factory::createGroupMember);
@@ -41,7 +39,7 @@ public class EmbeddedCacheManagerGroup<A extends Comparable<A>, M extends GroupM
 
 	@Override
 	public String getName() {
-		return this.name;
+		return this.group.getName();
 	}
 
 	@Override

--- a/server/infinispan/src/test/java/org/wildfly/clustering/server/infinispan/EmbeddedCacheManagerGroupProvider.java
+++ b/server/infinispan/src/test/java/org/wildfly/clustering/server/infinispan/EmbeddedCacheManagerGroupProvider.java
@@ -62,11 +62,6 @@ public class EmbeddedCacheManagerGroupProvider implements CacheContainerGroupPro
 	}
 
 	@Override
-	public String getName() {
-		return CONTAINER_NAME;
-	}
-
-	@Override
 	public void close() {
 		try {
 			this.manager.close();

--- a/server/jgroups/src/test/java/org/wildfly/clustering/server/jgroups/GroupITCase.java
+++ b/server/jgroups/src/test/java/org/wildfly/clustering/server/jgroups/GroupITCase.java
@@ -63,7 +63,7 @@ public abstract class GroupITCase<A extends Comparable<A>, M extends GroupMember
 			Group<A, M> group1 = provider1.getGroup();
 			JChannel channel1 = provider1.getChannel();
 
-			assertSame(provider1.getName(), group1.getName());
+			assertSame(channel1.getClusterName(), group1.getName());
 			assertEquals(MEMBER_NAMES[0], group1.getLocalMember().getName());
 			assertFalse(group1.isSingleton());
 			this.validate(channel1, group1);
@@ -129,7 +129,7 @@ public abstract class GroupITCase<A extends Comparable<A>, M extends GroupMember
 
 					Group<A, M> group2 = provider2.getGroup();
 
-					assertSame(provider2.getName(), group2.getName());
+					assertSame(channel2.getClusterName(), group2.getName());
 					assertEquals(MEMBER_NAMES[1], group2.getLocalMember().getName());
 					assertFalse(group2.isSingleton());
 
@@ -167,7 +167,7 @@ public abstract class GroupITCase<A extends Comparable<A>, M extends GroupMember
 
 						Group<A, M> group3 = provider3.getGroup();
 
-						assertSame(provider3.getName(), group3.getName());
+						assertSame(channel3.getClusterName(), group3.getName());
 						assertEquals(MEMBER_NAMES[2], group3.getLocalMember().getName());
 						assertFalse(group3.isSingleton());
 

--- a/server/jgroups/src/test/java/org/wildfly/clustering/server/jgroups/GroupProvider.java
+++ b/server/jgroups/src/test/java/org/wildfly/clustering/server/jgroups/GroupProvider.java
@@ -20,8 +20,6 @@ public interface GroupProvider<A extends Comparable<A>, M extends GroupMember<A>
 
 	Group<A, M> getGroup();
 
-	String getName();
-
 	@Override
 	void close();
 }

--- a/server/jgroups/src/test/java/org/wildfly/clustering/server/jgroups/JChannelGroupProvider.java
+++ b/server/jgroups/src/test/java/org/wildfly/clustering/server/jgroups/JChannelGroupProvider.java
@@ -34,11 +34,6 @@ public class JChannelGroupProvider implements GroupProvider<Address, ChannelGrou
 	}
 
 	@Override
-	public String getName() {
-		return this.channel.getClusterName();
-	}
-
-	@Override
 	public void close() {
 		this.group.close();
 		this.channel.disconnect();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFC-11