### PR TITLE
Fix race conditions in CacheStrategy.CONCURRENT

### DIFF
--- a/server/spi/src/main/java/org/wildfly/clustering/server/cache/CacheStrategy.java
+++ b/server/spi/src/main/java/org/wildfly/clustering/server/cache/CacheStrategy.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Generic level-one cache implementations.
@@ -46,51 +47,71 @@ public enum CacheStrategy implements CacheFactory {
 	CONCURRENT() {
 		@Override
 		public <K, V> Cache<K, V> createCache(Consumer<V> startTask, Consumer<V> stopTask) {
-			BiFunction<K, Map.Entry<Integer, AtomicReference<V>>, Map.Entry<Integer, AtomicReference<V>>> addFunction = new BiFunction<>() {
-				@Override
-				public Map.Entry<Integer, AtomicReference<V>> apply(K id, Map.Entry<Integer, AtomicReference<V>> entry) {
-					return (entry != null) ? Map.entry(entry.getKey() + 1, entry.getValue()) : Map.entry(0, new AtomicReference<>());
-				}
-			};
-			BiFunction<K, Map.Entry<Integer, AtomicReference<V>>, Map.Entry<Integer, AtomicReference<V>>> removeFunction = new BiFunction<>() {
-				@Override
-				public Map.Entry<Integer, AtomicReference<V>> apply(K key, Map.Entry<Integer, AtomicReference<V>> entry) {
-					// Entry can be null if entry was already removed, i.e. managed object was already closed
-					int count = (entry != null) ? entry.getKey() : 0;
-					AtomicReference<V> reference = (entry != null) ? entry.getValue() : null;
-					if (count == 0) {
-						Optional.ofNullable(reference).map(AtomicReference::getPlain).ifPresent(stopTask::accept);
-						// Returning null will remove the map entry
-						return null;
-					}
-					return Map.entry(count - 1, reference);
-				}
-			};
+			BiFunction<K, Map.Entry<Integer, Object>, Map.Entry<Integer, Object>> addMutexFunction = new AddIfAbsentFunction<>(Object::new);
+			BiFunction<K, Map.Entry<Integer, Object>, Map.Entry<Integer, Object>> removeMutexFunction = new RemoveIfPresentFunction<>();
+			BiFunction<K, Map.Entry<Integer, AtomicReference<V>>, Map.Entry<Integer, AtomicReference<V>>> addReferenceFunction = new AddIfAbsentFunction<>(AtomicReference::new);
+			BiFunction<K, Map.Entry<Integer, AtomicReference<V>>, Map.Entry<Integer, AtomicReference<V>>> removeReferenceFunction = new RemoveIfPresentFunction<>();
 			return new Cache<>() {
-				private final Map<K, Map.Entry<Integer, AtomicReference<V>>> entries = new ConcurrentHashMap<>();
+				private final Map<K, Map.Entry<Integer, Object>> mutexes = new ConcurrentHashMap<>();
+				private final Map<K, Map.Entry<Integer, AtomicReference<V>>> references = new ConcurrentHashMap<>();
 
 				@Override
 				public V computeIfAbsent(K key, BiFunction<K, Runnable, V> factory) {
-					Map.Entry<Integer, AtomicReference<V>> entry = this.entries.compute(key, addFunction);
-					AtomicReference<V> reference = entry.getValue();
-					if (reference.getPlain() == null) {
-						synchronized (reference) {
-							if (reference.getPlain() == null) {
-								Runnable closeTask = () -> this.entries.compute(key, removeFunction);
-								V value = factory.apply(key, closeTask);
-								if (value != null) {
-									startTask.accept(value);
-									reference.setPlain(value);
+					Object mutex = this.mutexes.compute(key, addMutexFunction).getValue();
+					AtomicReference<V> reference = this.references.compute(key, addReferenceFunction).getValue();
+					V result = reference.get();
+					if (result == null) {
+						// Restrict creation to a single thread
+						synchronized (mutex) {
+							result = reference.get();
+							if (result == null) {
+								Runnable closeTask = () -> {
+									// Block attempts to recreate object until stop task completes
+									if (this.references.compute(key, removeReferenceFunction) == null) {
+										synchronized (mutex) {
+											V value = reference.get();
+											if (value != null) {
+												stopTask.accept(value);
+											}
+										}
+									}
+									this.mutexes.compute(key, removeMutexFunction);
+								};
+								result = factory.apply(key, closeTask);
+								if (result != null) {
+									startTask.accept(result);
+									reference.set(result);
 								} else {
 									closeTask.run();
 								}
 							}
 						}
 					}
-					return reference.get();
+					return result;
 				}
 			};
 		}
 	},
 	;
+	private static class AddIfAbsentFunction<K, V> implements BiFunction<K, Map.Entry<Integer, V>, Map.Entry<Integer, V>> {
+		private Supplier<V> factory;
+
+		AddIfAbsentFunction(Supplier<V> factory) {
+			this.factory = factory;
+		}
+
+		@Override
+		public Map.Entry<Integer, V> apply(K id, Map.Entry<Integer, V> entry) {
+			return (entry != null) ? Map.entry(entry.getKey() + 1, entry.getValue()) : Map.entry(0, this.factory.get());
+		}
+	}
+
+	private static class RemoveIfPresentFunction<K, V> implements BiFunction<K, Map.Entry<Integer, V>, Map.Entry<Integer, V>> {
+		@Override
+		public Map.Entry<Integer, V> apply(K id, Map.Entry<Integer, V> entry) {
+			int count = (entry != null) ? entry.getKey() : 0;
+			// Returning null will remove the map entry
+			return (count > 0) ? Map.entry(count - 1, entry.getValue()) : null;
+		}
+	}
 }


### PR DESCRIPTION
Ensure object creation blocks until any previous stop action is complete.