### PR TITLE
Drop dependencies on jboss-logging and wildfly-common

### DIFF
--- a/cache/infinispan/common/src/main/java/org/wildfly/clustering/cache/infinispan/batch/TransactionBatch.java
+++ b/cache/infinispan/common/src/main/java/org/wildfly/clustering/cache/infinispan/batch/TransactionBatch.java
@@ -16,7 +16,6 @@ import jakarta.transaction.SystemException;
 import jakarta.transaction.Transaction;
 import jakarta.transaction.TransactionManager;
 
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.batch.Batch;
 import org.wildfly.clustering.cache.batch.SuspendedBatch;
 
@@ -51,7 +50,7 @@ public interface TransactionBatch extends Batch, SuspendedBatch {
 	 * @return a new transaction batcher
 	 */
 	static <E extends RuntimeException> Factory factory(String name, TransactionManager tm, Function<Throwable, E> exceptionTransformer) {
-		Logger logger = Logger.getLogger(TransactionBatch.class, name);
+		System.Logger logger = System.getLogger(String.join(".", TransactionBatch.class.getName(), name));
 		Synchronization synchronization = new Synchronization() {
 			@Override
 			public void beforeCompletion() {

--- a/cache/infinispan/embedded/src/main/java/org/wildfly/clustering/cache/infinispan/embedded/EmbeddedCacheEntryComputer.java
+++ b/cache/infinispan/embedded/src/main/java/org/wildfly/clustering/cache/infinispan/embedded/EmbeddedCacheEntryComputer.java
@@ -11,7 +11,7 @@ import java.util.function.BiFunction;
 import org.infinispan.Cache;
 import org.infinispan.context.Flag;
 import org.wildfly.clustering.cache.CacheEntryMutator;
-import org.wildfly.common.function.Functions;
+import org.wildfly.clustering.function.Consumer;
 
 /**
  * Mutator for a cache entry using a compute function.
@@ -34,6 +34,6 @@ public class EmbeddedCacheEntryComputer<K, V> implements CacheEntryMutator {
 	@Override
 	public CompletionStage<Void> mutateAsync() {
 		// Use FAIL_SILENTLY to prevent mutation from failing locally due to remote exceptions
-		return this.cache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES, Flag.FAIL_SILENTLY).computeAsync(this.key, this.function).thenAccept(Functions.discardingConsumer());
+		return this.cache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES, Flag.FAIL_SILENTLY).computeAsync(this.key, this.function).thenAccept(Consumer.empty());
 	}
 }

--- a/cache/infinispan/embedded/src/main/java/org/wildfly/clustering/cache/infinispan/embedded/EmbeddedCacheEntryMutator.java
+++ b/cache/infinispan/embedded/src/main/java/org/wildfly/clustering/cache/infinispan/embedded/EmbeddedCacheEntryMutator.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.infinispan.Cache;
 import org.infinispan.context.Flag;
 import org.wildfly.clustering.cache.CacheEntryMutator;
-import org.wildfly.common.function.Functions;
+import org.wildfly.clustering.function.Consumer;
 
 /**
  * Mutates a given cache entry.
@@ -44,7 +44,7 @@ public class EmbeddedCacheEntryMutator<K, V> implements CacheEntryMutator {
 		// We only ever have to perform a replace once within a batch
 		if ((this.mutated == null) || this.mutated.compareAndSet(false, true)) {
 			// Use FAIL_SILENTLY to prevent mutation from failing locally due to remote exceptions
-			return this.cache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES, Flag.FAIL_SILENTLY).putAsync(this.key, this.value).thenAccept(Functions.discardingConsumer());
+			return this.cache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES, Flag.FAIL_SILENTLY).putAsync(this.key, this.value).thenAccept(Consumer.empty());
 		}
 		return CompletableFuture.completedFuture(null);
 	}

--- a/cache/infinispan/embedded/src/main/java/org/wildfly/clustering/cache/infinispan/embedded/affinity/DefaultKeyAffinityService.java
+++ b/cache/infinispan/embedded/src/main/java/org/wildfly/clustering/cache/infinispan/embedded/affinity/DefaultKeyAffinityService.java
@@ -37,7 +37,6 @@ import org.infinispan.notifications.cachelistener.annotation.TopologyChanged;
 import org.infinispan.notifications.cachelistener.event.TopologyChangedEvent;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.concurrent.BlockingManager;
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.infinispan.embedded.distribution.KeyDistribution;
 
 /**
@@ -58,7 +57,7 @@ public class DefaultKeyAffinityService<K> implements KeyAffinityService<K>, Supp
 	private static final BiFunction<Cache<?, ?>, ConsistentHash, KeyDistribution> KEY_DISTRIBUTION_FACTORY = KeyDistribution::forConsistentHash;
 
 	static final int DEFAULT_QUEUE_SIZE = 100;
-	private static final Logger LOGGER = Logger.getLogger(DefaultKeyAffinityService.class);
+	private static final System.Logger LOGGER = System.getLogger(DefaultKeyAffinityService.class.getName());
 
 	private final Cache<? extends K, ?> cache;
 	private final KeyGenerator<? extends K> generator;
@@ -151,7 +150,7 @@ public class DefaultKeyAffinityService<K> implements KeyAffinityService<K>, Supp
 				return this.getCollocatedKey(currentState, otherKey);
 			}
 		}
-		LOGGER.debugf("Could not obtain pre-generated key with same affinity as %s -- generating random key", otherKey);
+		LOGGER.log(System.Logger.Level.DEBUG, "Could not obtain pre-generated key with same affinity as {0} -- generating random key", otherKey);
 		return this.generator.getKey();
 	}
 
@@ -175,7 +174,7 @@ public class DefaultKeyAffinityService<K> implements KeyAffinityService<K>, Supp
 				return this.getKeyForAddress(currentState, address);
 			}
 		}
-		LOGGER.debugf("Could not obtain pre-generated key with affinity for %s -- generating random key", address);
+		LOGGER.log(System.Logger.Level.DEBUG, "Could not obtain pre-generated key with affinity for {0} -- generating random key", address);
 		return this.generator.getKey();
 	}
 
@@ -196,7 +195,7 @@ public class DefaultKeyAffinityService<K> implements KeyAffinityService<K>, Supp
 	@TopologyChanged
 	public CompletionStage<Void> topologyChanged(TopologyChangedEvent<?, ?> event) {
 		if (!this.getSegments(event.getWriteConsistentHashAtStart()).equals(this.getSegments(event.getWriteConsistentHashAtEnd()))) {
-			LOGGER.debugf("Restarting key generation based on new consistent hash for topology %d", event.getNewTopologyId());
+			LOGGER.log(System.Logger.Level.DEBUG, "Restarting key generation based on new consistent hash for topology {0}", event.getNewTopologyId());
 			this.accept(event.getWriteConsistentHashAtEnd());
 		}
 		return CompletableFuture.completedStage(null);

--- a/cache/infinispan/embedded/src/main/java/org/wildfly/clustering/cache/infinispan/embedded/distribution/ConsistentHashKeyDistribution.java
+++ b/cache/infinispan/embedded/src/main/java/org/wildfly/clustering/cache/infinispan/embedded/distribution/ConsistentHashKeyDistribution.java
@@ -6,13 +6,12 @@
 package org.wildfly.clustering.cache.infinispan.embedded.distribution;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 import org.infinispan.Cache;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.remoting.transport.Address;
-import org.wildfly.common.function.Functions;
+import org.wildfly.clustering.function.Supplier;
 
 /**
  * Key distribution functions for a specific {@link ConsistentHash}.
@@ -28,7 +27,7 @@ public class ConsistentHashKeyDistribution implements KeyDistribution {
 	}
 
 	ConsistentHashKeyDistribution(Cache<?, ?> cache, ConsistentHash hash) {
-		this(cache, Functions.constantSupplier(hash));
+		this(cache, Supplier.of(hash));
 	}
 
 	private ConsistentHashKeyDistribution(Cache<?, ?> cache, Supplier<ConsistentHash> hash) {

--- a/cache/infinispan/embedded/src/main/java/org/wildfly/clustering/cache/infinispan/embedded/persistence/FormatterKeyMapper.java
+++ b/cache/infinispan/embedded/src/main/java/org/wildfly/clustering/cache/infinispan/embedded/persistence/FormatterKeyMapper.java
@@ -5,8 +5,6 @@
 
 package org.wildfly.clustering.cache.infinispan.embedded.persistence;
 
-import static org.wildfly.common.Assert.checkNotNullParam;
-
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.IdentityHashMap;
@@ -73,7 +71,6 @@ public class FormatterKeyMapper implements TwoWayKey2StringMapper {
 
 	@Override
 	public String getStringMapping(Object key) {
-		checkNotNullParam("key", key);
 		Integer index = this.indexes.get(key.getClass());
 		if (index == null) {
 			throw new IllegalArgumentException(key.getClass().getName());

--- a/cache/infinispan/embedded/src/test/java/org/wildfly/clustering/cache/infinispan/embedded/distribution/ConsistentHashKeyDistributionTestCase.java
+++ b/cache/infinispan/embedded/src/test/java/org/wildfly/clustering/cache/infinispan/embedded/distribution/ConsistentHashKeyDistributionTestCase.java
@@ -14,7 +14,7 @@ import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.remoting.transport.Address;
 import org.junit.jupiter.api.Test;
-import org.wildfly.common.function.Functions;
+import org.wildfly.clustering.function.Supplier;
 
 /**
  * @author Paul Ferraro
@@ -26,7 +26,7 @@ public class ConsistentHashKeyDistributionTestCase {
 		KeyPartitioner partitioner = mock(KeyPartitioner.class);
 		DistributionManager dist = mock(DistributionManager.class);
 		ConsistentHash hash = mock(ConsistentHash.class);
-		KeyDistribution distribution = new ConsistentHashKeyDistribution(dist, Functions.constantSupplier(hash));
+		KeyDistribution distribution = new ConsistentHashKeyDistribution(dist, Supplier.of(hash));
 
 		Address address = mock(Address.class);
 		Object key = new Object();

--- a/cache/infinispan/embedded/src/test/java/org/wildfly/clustering/cache/infinispan/embedded/persistence/FormatterTesterFactory.java
+++ b/cache/infinispan/embedded/src/test/java/org/wildfly/clustering/cache/infinispan/embedded/persistence/FormatterTesterFactory.java
@@ -17,6 +17,7 @@ import org.wildfly.clustering.marshalling.TesterFactory;
  * @author Paul Ferraro
  */
 public interface FormatterTesterFactory extends TesterFactory {
+	System.Logger LOGGER = System.getLogger(FormatterTesterFactory.class.getName());
 
 	@Override
 	default <T> Tester<T> createTester(BiConsumer<T, T> assertion) {
@@ -28,7 +29,7 @@ public interface FormatterTesterFactory extends TesterFactory {
 				assertThat(mapper.isSupportedType(keyClass)).as(key::toString).isTrue();
 				String string = mapper.getStringMapping(key);
 
-				System.out.println(String.format("%s\t%s\t%s\t%s", mapper.getClass().getSimpleName(), keyClass.getCanonicalName(), key, string));
+				LOGGER.log(System.Logger.Level.DEBUG, "{0}\t{1}\t{2}\t{3}", mapper.getClass().getSimpleName(), keyClass.getCanonicalName(), key, string);
 
 				@SuppressWarnings("unchecked")
 				T remappedKey = (T) mapper.getKeyMapping(string);

--- a/cache/infinispan/remote/src/main/java/org/wildfly/clustering/cache/infinispan/remote/RemoteCacheEntryComputer.java
+++ b/cache/infinispan/remote/src/main/java/org/wildfly/clustering/cache/infinispan/remote/RemoteCacheEntryComputer.java
@@ -9,11 +9,11 @@ import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-import java.util.function.Supplier;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.wildfly.clustering.cache.CacheEntryMutator;
-import org.wildfly.common.function.Functions;
+import org.wildfly.clustering.function.Consumer;
+import org.wildfly.clustering.function.Supplier;
 
 /**
  * Mutator for a cache entry using a compute function.
@@ -26,13 +26,13 @@ public class RemoteCacheEntryComputer<K, V> implements CacheEntryMutator {
 	private final RemoteCache<K, V> cache;
 	private final K key;
 	private final BiFunction<Object, V, V> function;
-	private final Supplier<Duration> maxIdle;
+	private final java.util.function.Supplier<Duration> maxIdle;
 
 	public RemoteCacheEntryComputer(RemoteCache<K, V> cache, K key, BiFunction<Object, V, V> function) {
-		this(cache, key, function, Functions.constantSupplier(Duration.ZERO));
+		this(cache, key, function, Supplier.of(Duration.ZERO));
 	}
 
-	public RemoteCacheEntryComputer(RemoteCache<K, V> cache, K key, BiFunction<Object, V, V> function, Supplier<Duration> maxIdle) {
+	public RemoteCacheEntryComputer(RemoteCache<K, V> cache, K key, BiFunction<Object, V, V> function, java.util.function.Supplier<Duration> maxIdle) {
 		this.cache = cache;
 		this.key = key;
 		this.function = function;
@@ -47,6 +47,6 @@ public class RemoteCacheEntryComputer<K, V> implements CacheEntryMutator {
 		if (nanos > 0) {
 			seconds += 1;
 		}
-		return this.cache.computeAsync(this.key, this.function, 0, TimeUnit.SECONDS, seconds, TimeUnit.SECONDS).thenAccept(Functions.discardingConsumer());
+		return this.cache.computeAsync(this.key, this.function, 0, TimeUnit.SECONDS, seconds, TimeUnit.SECONDS).thenAccept(Consumer.empty());
 	}
 }

--- a/cache/infinispan/remote/src/main/java/org/wildfly/clustering/cache/infinispan/remote/RemoteCacheEntryMutator.java
+++ b/cache/infinispan/remote/src/main/java/org/wildfly/clustering/cache/infinispan/remote/RemoteCacheEntryMutator.java
@@ -8,11 +8,11 @@ package org.wildfly.clustering.cache.infinispan.remote;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.wildfly.clustering.cache.CacheEntryMutator;
-import org.wildfly.common.function.Functions;
+import org.wildfly.clustering.function.Consumer;
+import org.wildfly.clustering.function.Supplier;
 
 /**
  * Mutates a given cache entry.
@@ -25,13 +25,13 @@ public class RemoteCacheEntryMutator<K, V> implements CacheEntryMutator {
 	private final RemoteCache<K, V> cache;
 	private final K id;
 	private final V value;
-	private final Supplier<Duration> maxIdle;
+	private final java.util.function.Supplier<Duration> maxIdle;
 
 	public RemoteCacheEntryMutator(RemoteCache<K, V> cache, K id, V value) {
-		this(cache, id, value, Functions.constantSupplier(Duration.ZERO));
+		this(cache, id, value, Supplier.of(Duration.ZERO));
 	}
 
-	public RemoteCacheEntryMutator(RemoteCache<K, V> cache, K id, V value, Supplier<Duration> maxIdle) {
+	public RemoteCacheEntryMutator(RemoteCache<K, V> cache, K id, V value, java.util.function.Supplier<Duration> maxIdle) {
 		this.cache = cache;
 		this.id = id;
 		this.value = value;
@@ -46,6 +46,6 @@ public class RemoteCacheEntryMutator<K, V> implements CacheEntryMutator {
 		if (nanos > 0) {
 			seconds += 1;
 		}
-		return this.cache.putAsync(this.id, this.value, 0, TimeUnit.SECONDS, seconds, TimeUnit.SECONDS).thenAccept(Functions.discardingConsumer());
+		return this.cache.putAsync(this.id, this.value, 0, TimeUnit.SECONDS, seconds, TimeUnit.SECONDS).thenAccept(Consumer.empty());
 	}
 }

--- a/cache/infinispan/remote/src/test/java/org/wildfly/clustering/cache/infinispan/remote/InfinispanServerContainer.java
+++ b/cache/infinispan/remote/src/test/java/org/wildfly/clustering/cache/infinispan/remote/InfinispanServerContainer.java
@@ -8,8 +8,6 @@ package org.wildfly.clustering.cache.infinispan.remote;
 import java.time.Duration;
 
 import org.infinispan.commons.util.Version;
-import org.jboss.logging.Logger;
-import org.jboss.logging.Logger.Level;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame;
@@ -23,7 +21,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class InfinispanServerContainer extends GenericContainer<InfinispanServerContainer> {
 
-	static final Logger LOGGER = Logger.getLogger(InfinispanServerContainer.class);
+	static final System.Logger LOGGER = System.getLogger(InfinispanServerContainer.class.getName());
 
 	static final String DOCKER_NETWORK_MODE_PROPERTY = "docker.network.mode";
 	static final String DOCKER_IMAGE_PROPERTY = "infinispan.server.image";
@@ -55,7 +53,7 @@ public class InfinispanServerContainer extends GenericContainer<InfinispanServer
 			OutputFrame.OutputType type = frame.getType();
 			if (type != OutputType.END) {
 				String message = frame.getUtf8String().replaceAll("((\\r?\\n)|(\\r))$", "");
-				LOGGER.logf(type == OutputType.STDERR ? Level.ERROR : Level.INFO, message);
+				LOGGER.log(type == OutputType.STDERR ? System.Logger.Level.ERROR : System.Logger.Level.INFO, message);
 			}
 		});
 		// Wait for server started log message

--- a/cache/spi/src/test/java/org/wildfly/clustering/cache/ContainerExtension.java
+++ b/cache/spi/src/test/java/org/wildfly/clustering/cache/ContainerExtension.java
@@ -9,7 +9,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.function.Function;
 
-import org.jboss.logging.Logger;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -22,7 +21,7 @@ import org.testcontainers.lifecycle.Startable;
  * @author Paul Ferraro
  */
 public class ContainerExtension<C extends Container<C> & Startable> implements AfterAllCallback, BeforeAllCallback, ContainerProvider<C> {
-	protected static final Logger LOGGER = Logger.getLogger(ContainerExtension.class);
+	protected static final System.Logger LOGGER = System.getLogger(ContainerExtension.class.getName());
 
 	private final Function<ExtensionContext, C> factory;
 	private C container;
@@ -39,19 +38,19 @@ public class ContainerExtension<C extends Container<C> & Startable> implements A
 	@Override
 	public void beforeAll(ExtensionContext context) throws Exception {
 		this.container = this.factory.apply(context);
-		LOGGER.infof("Starting %s", this.container.getDockerImageName());
+		LOGGER.log(System.Logger.Level.INFO, "Starting {0}", this.container.getDockerImageName());
 		Instant start = Instant.now();
 		this.container.start();
-		LOGGER.infof("Started %s in %s", this.container.getDockerImageName(), Duration.between(start, Instant.now()));
+		LOGGER.log(System.Logger.Level.INFO, "Started {0} in {1}", this.container.getDockerImageName(), Duration.between(start, Instant.now()));
 	}
 
 	@Override
 	public void afterAll(ExtensionContext context) throws Exception {
 		if (this.container != null) {
-			LOGGER.infof("Starting %s", this.container.getDockerImageName());
+			LOGGER.log(System.Logger.Level.INFO, "Stopping {0}", this.container.getDockerImageName());
 			Instant start = Instant.now();
 			this.container.stop();
-			LOGGER.infof("Stopped %s in %s", this.container.getDockerImageName(), Duration.between(start, Instant.now()));
+			LOGGER.log(System.Logger.Level.INFO, "Stopped {0} in {1}", this.container.getDockerImageName(), Duration.between(start, Instant.now()));
 		}
 	}
 }

--- a/function/src/main/java/org/wildfly/clustering/function/Consumer.java
+++ b/function/src/main/java/org/wildfly/clustering/function/Consumer.java
@@ -40,6 +40,22 @@ public interface Consumer<T> extends java.util.function.Consumer<T> {
 		public void accept(Object value) {
 		}
 	};
+	Consumer<AutoCloseable> CLOSE = new Consumer<>() {
+		private final System.Logger logger = System.getLogger(this.getClass().getPackageName());
+
+		@Override
+		public void accept(AutoCloseable object) {
+			if (object != null) {
+				try {
+					object.close();
+				} catch (RuntimeException e) {
+					throw e;
+				} catch (Exception e) {
+					this.logger.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
+				}
+			}
+		}
+	};
 
 	/**
 	 * Returns a consumer that performs no action.
@@ -49,6 +65,16 @@ public interface Consumer<T> extends java.util.function.Consumer<T> {
 	@SuppressWarnings("unchecked")
 	static <V> Consumer<V> empty() {
 		return (Consumer<V>) EMPTY;
+	}
+
+	/**
+	 * Returns a consumer that performs no action.
+	 * @param <V> the consumed type
+	 * @return an empty consumer
+	 */
+	@SuppressWarnings("unchecked")
+	static <V extends AutoCloseable> Consumer<V> close() {
+		return (Consumer<V>) CLOSE;
 	}
 
 	/**

--- a/function/src/main/java/org/wildfly/clustering/function/Consumer.java
+++ b/function/src/main/java/org/wildfly/clustering/function/Consumer.java
@@ -41,7 +41,7 @@ public interface Consumer<T> extends java.util.function.Consumer<T> {
 		}
 	};
 	Consumer<AutoCloseable> CLOSE = new Consumer<>() {
-		private final System.Logger logger = System.getLogger(this.getClass().getPackageName());
+		private final System.Logger logger = System.getLogger(Consumer.class.getName());
 
 		@Override
 		public void accept(AutoCloseable object) {

--- a/marshalling/protostream/src/main/java/org/wildfly/clustering/marshalling/protostream/SerializationContextBuilder.java
+++ b/marshalling/protostream/src/main/java/org/wildfly/clustering/marshalling/protostream/SerializationContextBuilder.java
@@ -20,7 +20,6 @@ import org.infinispan.protostream.ImmutableSerializationContext;
 import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.config.Configuration;
 import org.infinispan.protostream.impl.SerializationContextImpl;
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.marshalling.MarshallerConfigurationBuilder;
 import org.wildfly.clustering.marshalling.protostream.math.MathSerializationContextInitializer;
 import org.wildfly.clustering.marshalling.protostream.net.NetSerializationContextInitializer;
@@ -75,7 +74,7 @@ public interface SerializationContextBuilder<I> extends MarshallerConfigurationB
 	}
 
 	class DefaultSerializationContextBuilder implements SerializationContextBuilder<SerializationContextInitializer> {
-		private static final Logger LOGGER = Logger.getLogger(DefaultSerializationContextBuilder.class);
+		private static final System.Logger LOGGER = System.getLogger(SerializationContextBuilder.class.getName());
 		private static final String PROTOSTREAM_BASE_PACKAGE_NAME = org.infinispan.protostream.BaseMarshaller.class.getPackage().getName();
 
 		private final SerializationContext context;
@@ -122,7 +121,7 @@ public interface SerializationContextBuilder<I> extends MarshallerConfigurationB
 						SerializationContextInitializer initializer = remaining.next();
 						try {
 							this.register(initializer);
-							LOGGER.debugf("Registering marshallers/schemas from %s", initializer.getClass().getName());
+							LOGGER.log(System.Logger.Level.DEBUG, "Registering marshallers/schemas from {0}", initializer.getClass().getName());
 							remaining.remove();
 						} catch (DescriptorParserException e) {
 							// Descriptor might fail to parse due to ordering issues
@@ -141,7 +140,7 @@ public interface SerializationContextBuilder<I> extends MarshallerConfigurationB
 		private void loadNative(ClassLoader loader) {
 			for (org.infinispan.protostream.SerializationContextInitializer initializer : loadAll(org.infinispan.protostream.SerializationContextInitializer.class, loader)) {
 				if (!initializer.getClass().getName().startsWith(PROTOSTREAM_BASE_PACKAGE_NAME)) {
-					LOGGER.debugf("Registering native marshallers/schemas from %s", initializer.getClass().getName());
+					LOGGER.log(System.Logger.Level.DEBUG, "Registering native marshallers/schemas from {0}", initializer.getClass().getName());
 					initializer.registerSchema(this.context);
 					initializer.registerMarshallers(this.context);
 				}

--- a/marshalling/spi/pom.xml
+++ b/marshalling/spi/pom.xml
@@ -22,11 +22,6 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>wildfly-clustering-context</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.jboss.logging</groupId>
-			<artifactId>jboss-logging</artifactId>
-		</dependency>
 	</dependencies>
 
 </project>

--- a/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/ByteBufferMarshalledValue.java
+++ b/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/ByteBufferMarshalledValue.java
@@ -13,8 +13,6 @@ import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.OptionalInt;
 
-import org.jboss.logging.Logger;
-
 /**
  * {@link MarshalledValue} implementation that uses a {@link ByteBufferMarshaller}.
  * @author Paul Ferraro
@@ -22,7 +20,6 @@ import org.jboss.logging.Logger;
  */
 public class ByteBufferMarshalledValue<V> implements MarshalledValue<V, ByteBufferMarshaller>, Serializable {
 	private static final long serialVersionUID = -8419893544424515905L;
-	private static final Logger LOGGER = Logger.getLogger(ByteBufferMarshalledValue.class);
 
 	private transient volatile ByteBufferMarshaller marshaller;
 	private transient volatile V object;
@@ -66,7 +63,7 @@ public class ByteBufferMarshalledValue<V> implements MarshalledValue<V, ByteBuff
 			buffer = this.marshaller.write(this.object);
 			// N.B. Refrain from logging wrapped object
 			// If wrapped object contains an EJB proxy, toString() will trigger an EJB invocation!
-			LOGGER.debugf("Marshalled size of %s object = %d bytes", this.object.getClass().getCanonicalName(), buffer.limit() - buffer.arrayOffset());
+			Logger.INSTANCE.log(System.Logger.Level.DEBUG, "Marshalled size of {0} object = {1} bytes", this.object.getClass().getCanonicalName(), buffer.limit() - buffer.arrayOffset());
 		}
 		return buffer;
 	}

--- a/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/ByteBufferMarshaller.java
+++ b/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/ByteBufferMarshaller.java
@@ -11,7 +11,6 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.OptionalInt;
 
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.context.Context;
 import org.wildfly.clustering.function.Supplier;
 
@@ -20,7 +19,6 @@ import org.wildfly.clustering.function.Supplier;
  * @author Paul Ferraro
  */
 public interface ByteBufferMarshaller extends Marshaller<Object, ByteBuffer> {
-	Logger LOGGER = Logger.getLogger(ByteBufferMarshaller.class);
 
 	/**
 	 * Reads an object from the specified input stream.
@@ -54,14 +52,16 @@ public interface ByteBufferMarshaller extends Marshaller<Object, ByteBuffer> {
 			try (ByteBufferOutputStream output = new ByteBufferOutputStream(size)) {
 				this.writeTo(output, object);
 				ByteBuffer buffer = output.getBuffer();
-				if (size.isPresent()) {
-					int predictedSize = size.getAsInt();
-					int actualSize = buffer.limit() - buffer.arrayOffset();
-					if (predictedSize < actualSize) {
-						LOGGER.debugf("Buffer size prediction too small for %s (%s), predicted = %d, actual = %d", object, (object != null) ? object.getClass().getCanonicalName() : null, predictedSize, actualSize);
+				if (Logger.INSTANCE.isLoggable(System.Logger.Level.DEBUG)) {
+					if (size.isPresent()) {
+						int predictedSize = size.getAsInt();
+						int actualSize = buffer.limit() - buffer.arrayOffset();
+						if (predictedSize < actualSize) {
+							Logger.INSTANCE.log(System.Logger.Level.DEBUG, "Buffer size prediction too small for {0} ({1}), predicted = {3}, actual = {4}", object, (object != null) ? object.getClass().getCanonicalName() : null, predictedSize, actualSize);
+						}
+					} else {
+						Logger.INSTANCE.log(System.Logger.Level.DEBUG, "Buffer size prediction missing for {0} ({1})", object, (object != null) ? object.getClass().getCanonicalName() : null);
 					}
-				} else {
-					LOGGER.tracef("Buffer size prediction missing for %s (%s)", object, (object != null) ? object.getClass().getCanonicalName() : null);
 				}
 				return buffer;
 			}

--- a/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/Logger.java
+++ b/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/Logger.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.clustering.marshalling;
+
+import java.util.ResourceBundle;
+
+/**
+ * @author Paul Ferraro
+ */
+enum Logger implements System.Logger {
+	INSTANCE;
+
+	private final System.Logger logger = System.getLogger(Marshaller.class.getName());
+
+	@Override
+	public String getName() {
+		return this.logger.getName();
+	}
+
+	@Override
+	public boolean isLoggable(Level level) {
+		return this.logger.isLoggable(level);
+	}
+
+	@Override
+	public void log(Level level, ResourceBundle bundle, String message, Throwable exception) {
+		this.logger.log(level, bundle, message, exception);
+	}
+
+	@Override
+	public void log(Level level, ResourceBundle bundle, String format, Object... params) {
+		this.logger.log(level, bundle, format, params);
+	}
+}

--- a/marshalling/spi/src/test/java/org/wildfly/clustering/marshalling/MarshallingTesterFactory.java
+++ b/marshalling/spi/src/test/java/org/wildfly/clustering/marshalling/MarshallingTesterFactory.java
@@ -18,6 +18,7 @@ import java.util.function.BiConsumer;
  * @author Paul Ferraro
  */
 public interface MarshallingTesterFactory extends TesterFactory {
+	System.Logger LOGGER = System.getLogger(MarshallingTesterFactory.class.getName());
 
 	default <T> Tester<T> createTester(BiConsumer<T, T> assertion) {
 		ByteBufferMarshaller marshaller = this.getMarshaller();
@@ -39,7 +40,7 @@ public interface MarshallingTesterFactory extends TesterFactory {
 					if (subject != null) {
 						Class<?> subjectClass = (subject instanceof Enum) ? ((Enum<?>) subject).getDeclaringClass() : subject.getClass();
 						Object subjectValue = (subject instanceof Character) ? (int) (Character) subject : subject;
-						System.out.println(String.format("%s\t%s\t%s\t%d", marshaller, subjectClass.getCanonicalName(), subjectValue, bufferSize));
+						LOGGER.log(System.Logger.Level.DEBUG, "{0}\t{1}\t{2}\t{3}", marshaller, subjectClass.getCanonicalName(), subjectValue, bufferSize);
 					}
 
 					@SuppressWarnings("unchecked")

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
 		<!-- Compile dependency versions -->
 		<version.io.github.resilience4j>2.3.0</version.io.github.resilience4j>
 		<version.org.infinispan>15.2.1.Final</version.org.infinispan>
-		<version.org.jboss.logging>3.6.1.Final</version.org.jboss.logging>
 		<version.org.jboss.logmanager>3.1.2.Final</version.org.jboss.logmanager>
 		<version.org.jboss.marshalling>2.2.3.Final</version.org.jboss.marshalling>
 		<version.org.jgroups>5.4.6.Final</version.org.jgroups>
@@ -137,11 +136,6 @@
 				<groupId>io.github.resilience4j</groupId>
 				<artifactId>resilience4j-retry</artifactId>
 				<version>${version.io.github.resilience4j}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.jboss.logging</groupId>
-				<artifactId>jboss-logging</artifactId>
-				<version>${version.org.jboss.logging}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.marshalling</groupId>

--- a/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/provider/CacheServiceProviderRegistrar.java
+++ b/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/provider/CacheServiceProviderRegistrar.java
@@ -34,7 +34,6 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
 import org.infinispan.notifications.cachelistener.event.TopologyChangedEvent;
 import org.infinispan.remoting.transport.Address;
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.batch.Batch;
 import org.wildfly.clustering.cache.infinispan.embedded.distribution.CacheStreamFilter;
 import org.wildfly.clustering.context.DefaultExecutorService;
@@ -54,7 +53,7 @@ import org.wildfly.clustering.server.provider.ServiceProviderRegistration;
  */
 @Listener(observation = Observation.POST)
 public class CacheServiceProviderRegistrar<T> implements CacheContainerServiceProviderRegistrar<T>, AutoCloseable {
-	private static final Logger LOGGER = Logger.getLogger(CacheServiceProviderRegistrar.class);
+	private static final System.Logger LOGGER = System.getLogger(CacheServiceProviderRegistrar.class.getName());
 
 	private final Supplier<Batch> batchFactory;
 	private final ConcurrentMap<T, Map.Entry<ServiceProviderListener<CacheContainerGroupMember>, ExecutorService>> listeners = new ConcurrentHashMap<>();
@@ -234,7 +233,7 @@ public class CacheServiceProviderRegistrar<T> implements CacheContainerServicePr
 						try {
 							listener.providersChanged(members);
 						} catch (Throwable e) {
-							LOGGER.warn(e.getLocalizedMessage(), e);
+							LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 						}
 					});
 				} catch (RejectedExecutionException e) {

--- a/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/registry/CacheRegistry.java
+++ b/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/registry/CacheRegistry.java
@@ -38,7 +38,6 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.notifications.cachelistener.event.TopologyChangedEvent;
 import org.infinispan.remoting.transport.Address;
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.batch.Batch;
 import org.wildfly.clustering.cache.infinispan.embedded.distribution.Locality;
 import org.wildfly.clustering.cache.infinispan.embedded.listener.KeyFilter;
@@ -58,7 +57,7 @@ import org.wildfly.clustering.server.registry.RegistryListener;
  */
 @Listener(observation = Observation.POST)
 public class CacheRegistry<K, V> implements CacheContainerRegistry<K, V> {
-	private static final Logger LOGGER = Logger.getLogger(CacheRegistry.class);
+	private static final System.Logger LOGGER = System.getLogger(CacheRegistry.class.getName());
 
 	private final Map<RegistryListener<K, V>, ExecutorService> listeners = new ConcurrentHashMap<>();
 	private final Cache<Address, Map.Entry<K, V>> cache;
@@ -100,7 +99,7 @@ public class CacheRegistry<K, V> implements CacheContainerRegistry<K, V> {
 			// If this remove fails, the entry will be auto-removed on topology change by the new primary owner
 			this.cache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES, Flag.FAIL_SILENTLY).remove(localAddress);
 		} catch (CacheException e) {
-			LOGGER.warn(e.getLocalizedMessage(), e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 		} finally {
 			// Cleanup any unregistered listeners
 			for (ExecutorService executor : this.listeners.values()) {
@@ -190,7 +189,7 @@ public class CacheRegistry<K, V> implements CacheContainerRegistry<K, V> {
 									}
 								}
 							} catch (CacheException e) {
-								LOGGER.warn(e.getLocalizedMessage(), e);
+								LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 							}
 							if (!removed.isEmpty()) {
 								this.notifyListeners(Event.Type.CACHE_ENTRY_REMOVED, removed);
@@ -204,7 +203,7 @@ public class CacheRegistry<K, V> implements CacheContainerRegistry<K, V> {
 									this.notifyListeners(Event.Type.CACHE_ENTRY_CREATED, this.entry);
 								}
 							} catch (CacheException e) {
-								LOGGER.warn(e.getLocalizedMessage(), e);
+								LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 							}
 						}
 					});
@@ -269,7 +268,7 @@ public class CacheRegistry<K, V> implements CacheContainerRegistry<K, V> {
 							}
 						}
 					} catch (Throwable e) {
-						LOGGER.warn(e.getLocalizedMessage(), e);
+						LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 					}
 				});
 			} catch (RejectedExecutionException e) {

--- a/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/scheduler/AbstractCacheEntryScheduler.java
+++ b/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/scheduler/AbstractCacheEntryScheduler.java
@@ -6,8 +6,8 @@
 package org.wildfly.clustering.server.infinispan.scheduler;
 
 import org.wildfly.clustering.cache.Key;
+import org.wildfly.clustering.function.Supplier;
 import org.wildfly.clustering.server.scheduler.Scheduler;
-import org.wildfly.common.function.Functions;
 
 /**
  * An abstract cache entry scheduler.
@@ -20,6 +20,6 @@ import org.wildfly.common.function.Functions;
 public abstract class AbstractCacheEntryScheduler<I, K extends Key<I>, V, M> extends Scheduler.ReferenceScheduler<I, M> implements CacheEntryScheduler<I, K, V, M> {
 
 	protected AbstractCacheEntryScheduler(Scheduler<I, M> scheduler) {
-		super(Functions.constantSupplier(scheduler));
+		super(Supplier.of(scheduler));
 	}
 }

--- a/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/scheduler/PrimaryOwnerScheduler.java
+++ b/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/scheduler/PrimaryOwnerScheduler.java
@@ -17,7 +17,6 @@ import java.util.function.Function;
 import io.github.resilience4j.core.functions.CheckedFunction;
 import io.github.resilience4j.retry.Retry;
 
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.server.dispatcher.CommandDispatcher;
 import org.wildfly.clustering.server.infinispan.CacheContainerGroupMember;
 import org.wildfly.clustering.server.util.MapEntry;
@@ -29,7 +28,7 @@ import org.wildfly.clustering.server.util.MapEntry;
  * @author Paul Ferraro
  */
 public class PrimaryOwnerScheduler<I, M> implements Scheduler<I, M> {
-	private static final Logger LOGGER = Logger.getLogger(PrimaryOwnerScheduler.class);
+	private static final System.Logger LOGGER = System.getLogger(PrimaryOwnerScheduler.class.getName());
 
 	private final String name;
 	private final CommandDispatcher<CacheContainerGroupMember, Scheduler<I, M>> dispatcher;
@@ -69,7 +68,7 @@ public class PrimaryOwnerScheduler<I, M> implements Scheduler<I, M> {
 		} catch (CancellationException e) {
 			// Ignore
 		} catch (Throwable e) {
-			LOGGER.warn(id.toString(), e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 		}
 	}
 
@@ -80,7 +79,7 @@ public class PrimaryOwnerScheduler<I, M> implements Scheduler<I, M> {
 		} catch (CancellationException e) {
 			// Ignore
 		} catch (Throwable e) {
-			LOGGER.warn(id.toString(), e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 		}
 	}
 
@@ -91,7 +90,7 @@ public class PrimaryOwnerScheduler<I, M> implements Scheduler<I, M> {
 		} catch (CancellationException e) {
 			// Ignore
 		} catch (Throwable e) {
-			LOGGER.warn(id.toString(), e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 		}
 	}
 
@@ -102,14 +101,14 @@ public class PrimaryOwnerScheduler<I, M> implements Scheduler<I, M> {
 		} catch (CancellationException e) {
 			return false;
 		} catch (Throwable e) {
-			LOGGER.warn(id.toString(), e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 			return false;
 		}
 	}
 
 	@Override
 	public void close() {
-		LOGGER.tracef("Closing command dispatcher for %s primary-owner scheduler", this.name);
+		LOGGER.log(System.Logger.Level.DEBUG, "Closing command dispatcher for {0} primary-owner scheduler", this.name);
 		this.dispatcher.close();
 		this.dispatcher.getContext().close();
 	}
@@ -129,7 +128,7 @@ public class PrimaryOwnerScheduler<I, M> implements Scheduler<I, M> {
 		public CompletionStage<R> apply(T value) throws IOException {
 			PrimaryOwnerCommand<I, M, R> command = this.commandFactory.apply(value);
 			CacheContainerGroupMember primaryOwner = this.affinity.apply(command.getId());
-			LOGGER.tracef("Executing command %s on %s", command, primaryOwner);
+			LOGGER.log(System.Logger.Level.DEBUG, "Executing command %s on %s", command, primaryOwner);
 			// This should only go remote following a failover
 			return this.dispatcher.dispatchToMember(command, primaryOwner);
 		}

--- a/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/scheduler/SchedulerTopologyChangeListener.java
+++ b/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/scheduler/SchedulerTopologyChangeListener.java
@@ -29,7 +29,6 @@ import org.infinispan.notifications.cachelistener.annotation.TopologyChanged;
 import org.infinispan.notifications.cachelistener.event.TopologyChangedEvent;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.concurrent.BlockingManager;
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.infinispan.embedded.distribution.CacheStreamFilter;
 import org.wildfly.clustering.cache.infinispan.embedded.listener.ListenerRegistrar;
 import org.wildfly.clustering.cache.infinispan.embedded.listener.ListenerRegistration;
@@ -45,7 +44,7 @@ import org.wildfly.clustering.context.DefaultThreadFactory;
  */
 @Listener
 public class SchedulerTopologyChangeListener<K, V, SE, CE> implements ListenerRegistrar {
-	private static final Logger LOGGER = Logger.getLogger(SchedulerTopologyChangeListener.class);
+	private static final System.Logger LOGGER = System.getLogger(SchedulerTopologyChangeListener.class.getName());
 	@SuppressWarnings("removal")
 	private static final ThreadFactory THREAD_FACTORY = new DefaultThreadFactory(SchedulerTopologyChangeListener.class, AccessController.doPrivileged(new PrivilegedAction<>() {
 		@Override
@@ -73,15 +72,15 @@ public class SchedulerTopologyChangeListener<K, V, SE, CE> implements ListenerRe
 		this.cache.addListener(this);
 		return () -> {
 			this.cache.removeListener(this);
-			LOGGER.debugf("Shutting down thread pool for %s scheduler topology change listener", this.cache.getName());
+			LOGGER.log(System.Logger.Level.DEBUG, "Shutting down thread pool for {0} scheduler topology change listener", this.cache.getName());
 			this.executor.shutdownNow();
 			try {
-				LOGGER.debugf("Awaiting task termination for %s scheduler topology change listener", this.cache.getName());
+				LOGGER.log(System.Logger.Level.DEBUG, "Awaiting task termination for {0} scheduler topology change listener", this.cache.getName());
 				this.executor.awaitTermination(this.cache.getCacheConfiguration().transaction().cacheStopTimeout(), TimeUnit.MILLISECONDS);
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 			}
-			LOGGER.debugf("%s scheduler topology change listener shutdown complete", this.cache.getName());
+			LOGGER.log(System.Logger.Level.DEBUG, "{0} scheduler topology change listener shutdown complete", this.cache.getName());
 		};
 	}
 
@@ -93,7 +92,7 @@ public class SchedulerTopologyChangeListener<K, V, SE, CE> implements ListenerRe
 		Set<Integer> oldSegments = oldHash.getMembers().contains(address) ? oldHash.getPrimarySegmentsForOwner(address) : Collections.emptySet();
 		ConsistentHash newHash = event.getWriteConsistentHashAtEnd();
 		Set<Integer> newSegments = newHash.getMembers().contains(address) ? newHash.getPrimarySegmentsForOwner(address) : Collections.emptySet();
-		LOGGER.debugf("%s scheduler topology change listener received %s-topology changed event: %s -> %s", cache.getName(), event.isPre() ? "pre" : "post", oldHash.getMembers(), newHash.getMembers());
+		LOGGER.log(System.Logger.Level.DEBUG, "{0} scheduler topology change listener received {1}-topology changed event: {2} -> {3}", cache.getName(), event.isPre() ? "pre" : "post", oldHash.getMembers(), newHash.getMembers());
 		if (event.isPre()) {
 			if (!oldSegments.isEmpty()) {
 				IntSet formerlyOwnedSegments = IntSets.mutableCopyFrom(oldSegments);

--- a/server/jgroups/src/main/java/org/wildfly/clustering/server/jgroups/JChannelGroup.java
+++ b/server/jgroups/src/main/java/org/wildfly/clustering/server/jgroups/JChannelGroup.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import org.jboss.logging.Logger;
 import org.jgroups.Address;
 import org.jgroups.JChannel;
 import org.jgroups.MergeView;
@@ -28,7 +27,7 @@ import org.wildfly.clustering.server.local.listener.LocalListenerRegistrar;
  * @author Paul Ferraro
  */
 public class JChannelGroup implements ChannelGroup, Receiver {
-	private static final Logger LOGGER = Logger.getLogger(JChannelGroup.class);
+	private static final System.Logger LOGGER = System.getLogger(JChannelGroup.class.getName());
 
 	private final String name;
 	private final ChannelGroupMemberFactory memberFactory = JChannelGroupMember::new;
@@ -96,7 +95,7 @@ public class JChannelGroup implements ChannelGroup, Receiver {
 				}
 			}
 		} catch (Throwable e) {
-			LOGGER.error(e.getLocalizedMessage(), e);
+			LOGGER.log(System.Logger.Level.ERROR, e.getLocalizedMessage(), e);
 		}
 	}
 

--- a/server/jgroups/src/main/java/org/wildfly/clustering/server/jgroups/dispatcher/CommandDispatcherRequestCorrelator.java
+++ b/server/jgroups/src/main/java/org/wildfly/clustering/server/jgroups/dispatcher/CommandDispatcherRequestCorrelator.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.function.Predicate;
 
-import org.jboss.logging.Logger;
 import org.jgroups.BytesMessage;
 import org.jgroups.JChannel;
 import org.jgroups.Message;
@@ -23,7 +22,7 @@ import org.wildfly.clustering.marshalling.ByteBufferMarshaller;
  * @author Paul Ferraro
  */
 public class CommandDispatcherRequestCorrelator extends RequestCorrelator {
-	private static final Logger LOGGER = Logger.getLogger(CommandDispatcherRequestCorrelator.class);
+	private static final System.Logger LOGGER = System.getLogger(CommandDispatcherRequestCorrelator.class.getName());
 
 	private final ByteBufferMarshaller marshaller;
 	private final Predicate<Message> unknownForkPredicate;
@@ -52,7 +51,7 @@ public class CommandDispatcherRequestCorrelator extends RequestCorrelator {
 						Object response = this.readPayload(message);
 						request.receiveResponse(response, message.getSrc(), exception);
 					} catch (IOException e) {
-						LOGGER.warn(e.getLocalizedMessage(), e);
+						LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 						request.receiveResponse(e, message.getSrc(), true);
 					}
 				}
@@ -83,7 +82,7 @@ public class CommandDispatcherRequestCorrelator extends RequestCorrelator {
 			ByteBuffer buffer = this.marshaller.write(reply);
 			response.setArray(buffer.array(), buffer.arrayOffset(), buffer.limit() - buffer.arrayOffset());
 		} catch (IOException e) {
-			LOGGER.warn(e.getLocalizedMessage(), e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 			response.setObject(e);
 		}
 		this.sendResponse(response, requestId, exception);

--- a/server/jgroups/src/test/java/org/wildfly/clustering/server/jgroups/GroupITCase.java
+++ b/server/jgroups/src/test/java/org/wildfly/clustering/server/jgroups/GroupITCase.java
@@ -42,6 +42,7 @@ public abstract class GroupITCase<A extends Comparable<A>, M extends GroupMember
 	private static final Duration VIEW_CHANGE_DURATION = Duration.ofSeconds(20);
 	private static final Duration SPLIT_MERGE_DURATION = Duration.ofSeconds(120);
 
+	private final System.Logger logger = System.getLogger(this.getClass().getName());
 	private final BiFunction<String, String, GroupProvider<A, M>> factory;
 	private final Function<A, Address> mapper;
 
@@ -105,7 +106,7 @@ public abstract class GroupITCase<A extends Comparable<A>, M extends GroupMember
 
 					Instant start = Instant.now();
 					updateEvent = updateEvents.poll(VIEW_CHANGE_DURATION.toSeconds(), TimeUnit.SECONDS);
-					System.out.println("View change detected after " + Duration.between(start, Instant.now()));
+					this.logger.log(System.Logger.Level.INFO, "View change detected after {0}", Duration.between(start, Instant.now()));
 					splitEvent = splitEvents.poll();
 					mergeEvent = mergeEvents.poll();
 
@@ -142,7 +143,7 @@ public abstract class GroupITCase<A extends Comparable<A>, M extends GroupMember
 
 						start = Instant.now();
 						updateEvent = updateEvents.poll(VIEW_CHANGE_DURATION.toSeconds(), TimeUnit.SECONDS);
-						System.out.println("View change detected after " + Duration.between(start, Instant.now()));
+						this.logger.log(System.Logger.Level.INFO, "View change detected after {0}", Duration.between(start, Instant.now()));
 						splitEvent = splitEvents.poll();
 						mergeEvent = mergeEvents.poll();
 
@@ -172,13 +173,13 @@ public abstract class GroupITCase<A extends Comparable<A>, M extends GroupMember
 						assertThat(membership3.getCoordinator()).isEqualTo(currentMembership.getCoordinator());
 						assertThat(membership3.getMembers()).containsExactlyElementsOf(currentMembership.getMembers());
 
-						System.out.println("Simulating network partition");
+						this.logger.log(System.Logger.Level.INFO, "Simulating network partition");
 						DISCARD discard1 = new DISCARD().discardAll(true);
 						channel1.getProtocolStack().insertProtocol(discard1, ProtocolStack.Position.ABOVE, TP.class);
 
 						start = Instant.now();
 						splitEvent = splitEvents.poll(SPLIT_MERGE_DURATION.toSeconds(), TimeUnit.SECONDS);
-						System.out.println("Network partition created after " + Duration.between(start, Instant.now()));
+						this.logger.log(System.Logger.Level.INFO, "Network partition created after {0}", Duration.between(start, Instant.now()));
 						updateEvent = updateEvents.poll();
 						mergeEvent = mergeEvents.poll();
 
@@ -198,12 +199,12 @@ public abstract class GroupITCase<A extends Comparable<A>, M extends GroupMember
 						assertThat(currentMembership.getMembers()).containsExactly(group1.getLocalMember());
 						assertThat(currentMembership.getCoordinator()).isEqualTo(group1.getLocalMember());
 
-						System.out.println("Resolving network partition");
+						this.logger.log(System.Logger.Level.INFO, "Resolving network partition");
 						channel1.getProtocolStack().removeProtocol(DISCARD.class);
 
 						start = Instant.now();
 						mergeEvent = mergeEvents.poll(SPLIT_MERGE_DURATION.toSeconds(), TimeUnit.SECONDS);
-						System.out.println("Network partition resolved after " + Duration.between(start, Instant.now()));
+						this.logger.log(System.Logger.Level.INFO, "Network partition resolved after {0}", Duration.between(start, Instant.now()));
 						splitEvent = splitEvents.poll();
 						updateEvent = updateEvents.poll();
 
@@ -226,7 +227,7 @@ public abstract class GroupITCase<A extends Comparable<A>, M extends GroupMember
 
 					start = Instant.now();
 					updateEvent = updateEvents.poll(VIEW_CHANGE_DURATION.toSeconds(), TimeUnit.SECONDS);
-					System.out.println("View change detected after " + Duration.between(start, Instant.now()));
+					this.logger.log(System.Logger.Level.INFO, "View change detected after {0}", Duration.between(start, Instant.now()));
 					splitEvent = splitEvents.poll();
 					mergeEvent = mergeEvents.poll();
 
@@ -247,7 +248,7 @@ public abstract class GroupITCase<A extends Comparable<A>, M extends GroupMember
 
 				Instant start = Instant.now();
 				updateEvent = updateEvents.poll(VIEW_CHANGE_DURATION.toSeconds(), TimeUnit.SECONDS);
-				System.out.println("View change detected after " + Duration.between(start, Instant.now()));
+				this.logger.log(System.Logger.Level.INFO, "View change detected after {0}", Duration.between(start, Instant.now()));
 				splitEvent = splitEvents.poll();
 				mergeEvent = mergeEvents.poll();
 

--- a/server/local/src/main/java/org/wildfly/clustering/server/local/listener/LocalListenerRegistrar.java
+++ b/server/local/src/main/java/org/wildfly/clustering/server/local/listener/LocalListenerRegistrar.java
@@ -15,7 +15,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.context.DefaultExecutorService;
 import org.wildfly.clustering.context.ExecutorServiceFactory;
 import org.wildfly.clustering.server.Registration;
@@ -27,7 +26,7 @@ import org.wildfly.clustering.server.listener.ListenerRegistrar;
  * @author Paul Ferraro
  */
 public class LocalListenerRegistrar<T> implements ListenerRegistrar<T> {
-	private static final Logger LOGGER = Logger.getLogger(LocalListenerRegistrar.class);
+	private static final System.Logger LOGGER = System.getLogger(LocalListenerRegistrar.class.getName());
 
 	private final Map<T, ExecutorService> listeners = new ConcurrentHashMap<>();
 	private final Duration shutdownTimeout;
@@ -61,7 +60,7 @@ public class LocalListenerRegistrar<T> implements ListenerRegistrar<T> {
 				}
 			}
 		} catch (Throwable e) {
-			LOGGER.error(e.getLocalizedMessage(), e);
+			LOGGER.log(System.Logger.Level.ERROR, e.getLocalizedMessage(), e);
 		}
 	}
 

--- a/server/local/src/main/java/org/wildfly/clustering/server/local/scheduler/LocalScheduler.java
+++ b/server/local/src/main/java/org/wildfly/clustering/server/local/scheduler/LocalScheduler.java
@@ -19,7 +19,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.server.scheduler.Scheduler;
 import org.wildfly.clustering.server.util.Reference;
 
@@ -29,7 +28,7 @@ import org.wildfly.clustering.server.util.Reference;
  * @author Paul Ferraro
  */
 public class LocalScheduler<T> implements Scheduler<T, Instant>, Runnable {
-	private static final Logger LOGGER = Logger.getLogger(LocalScheduler.class);
+	private static final System.Logger LOGGER = System.getLogger(LocalScheduler.class.getName());
 
 	private final String name;
 	private final ScheduledExecutorService executor;
@@ -71,7 +70,7 @@ public class LocalScheduler<T> implements Scheduler<T, Instant>, Runnable {
 
 	@Override
 	public void schedule(T id, Instant instant) {
-		LOGGER.tracef("Scheduling %s on local %s scheduler for %s", id, this.name, instant);
+		LOGGER.log(System.Logger.Level.TRACE, "Scheduling {1} on local {0} scheduler for {2}", this.name, id, instant);
 		this.entries.add(id, instant);
 		// Reschedule next task if this item is now the earliest task
 		// This can only be the case if the ScheduledEntries is sorted
@@ -84,7 +83,7 @@ public class LocalScheduler<T> implements Scheduler<T, Instant>, Runnable {
 
 	@Override
 	public void cancel(T id) {
-		LOGGER.tracef("Canceling %s on local %s scheduler", id, this.name);
+		LOGGER.log(System.Logger.Level.TRACE, "Canceling {1} on local {0} scheduler", this.name, id);
 		// Cancel scheduled task if this item was currently scheduled
 		if (this.entries.isSorted()) {
 			this.cancelIfPresent(id);
@@ -103,17 +102,17 @@ public class LocalScheduler<T> implements Scheduler<T, Instant>, Runnable {
 
 	@Override
 	public void close() {
-		LOGGER.debugf("Shutting down local %s scheduler", this.name);
+		LOGGER.log(System.Logger.Level.DEBUG, "Shutting down local {0} scheduler", this.name);
 		this.executor.shutdown();
 		if (!this.closeTimeout.isNegative() && !this.closeTimeout.isZero()) {
 			try {
-				LOGGER.debugf("Waiting for local %s scheduler tasks to complete", this.name);
+				LOGGER.log(System.Logger.Level.DEBUG, "Waiting for local {0} scheduler tasks to complete", this.name);
 				this.executor.awaitTermination(this.closeTimeout.toMillis(), TimeUnit.MILLISECONDS);
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 			}
 		}
-		LOGGER.debugf("Local %s scheduler shutdown complete", this.name);
+		LOGGER.log(System.Logger.Level.DEBUG, "Local {0} scheduler shutdown complete", this.name);
 	}
 
 	@Override
@@ -126,7 +125,7 @@ public class LocalScheduler<T> implements Scheduler<T, Instant>, Runnable {
 			// If this is a future entry, break out of loop
 			if (entry.getValue().isAfter(Instant.now())) break;
 			T key = entry.getKey();
-			LOGGER.tracef("Executing task for %s on local %s scheduler", key, this.name);
+			LOGGER.log(System.Logger.Level.TRACE, "Executing task for {1} on local {0} scheduler", this.name, key);
 			// Remove only if task is successful
 			if (this.task.test(key)) {
 				entries.remove();

--- a/session/cache/src/main/java/org/wildfly/clustering/session/cache/AbstractSessionManager.java
+++ b/session/cache/src/main/java/org/wildfly/clustering/session/cache/AbstractSessionManager.java
@@ -10,7 +10,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.CacheConfiguration;
 import org.wildfly.clustering.cache.batch.Batch;
 import org.wildfly.clustering.server.expiration.Expiration;
@@ -29,7 +28,7 @@ import org.wildfly.clustering.session.SessionStatistics;
  * @author Paul Ferraro
  */
 public abstract class AbstractSessionManager<C, MV, AV, SC> implements SessionManager<SC>, SessionStatistics {
-	protected final Logger logger = Logger.getLogger(this.getClass());
+	protected final System.Logger logger = System.getLogger(this.getClass().getName());
 
 	private final Supplier<SessionManager<SC>> manager;
 	private final SessionFactory<C, MV, AV, SC> factory;
@@ -68,21 +67,21 @@ public abstract class AbstractSessionManager<C, MV, AV, SC> implements SessionMa
 
 	@Override
 	public CompletionStage<Session<SC>> createSessionAsync(String id) {
-		this.logger.tracef("Creating session %s", id);
+		this.logger.log(System.Logger.Level.TRACE, "Creating session {0}", id);
 		return this.factory.createValueAsync(id, this.expiration.getTimeout()).thenApply(entry -> this.wrapper.apply(this.factory.createSession(id, entry, this.context)));
 	}
 
 	@Override
 	public CompletionStage<Session<SC>> findSessionAsync(String id) {
-		this.logger.tracef("Locating session %s", id);
+		this.logger.log(System.Logger.Level.TRACE, "Locating session {0}", id);
 		return this.factory.findValueAsync(id).thenApply(entry -> {
 			if (entry == null) {
-				this.logger.tracef("Session %s not found", id);
+				this.logger.log(System.Logger.Level.TRACE, "Session {0} not found", id);
 				return null;
 			}
 			ImmutableSession session = this.factory.createImmutableSession(id, entry);
 			if (session.getMetaData().isExpired()) {
-				this.logger.tracef("Session %s was found, but has expired", id);
+				this.logger.log(System.Logger.Level.TRACE, "Session {0} was found, but has expired", id);
 				this.expirationListener.accept(session);
 				this.factory.removeAsync(id);
 				return null;

--- a/session/cache/src/main/java/org/wildfly/clustering/session/cache/CachedSessionManager.java
+++ b/session/cache/src/main/java/org/wildfly/clustering/session/cache/CachedSessionManager.java
@@ -12,7 +12,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.function.Consumer;
 import org.wildfly.clustering.function.Function;
 import org.wildfly.clustering.function.Supplier;
@@ -28,7 +27,7 @@ import org.wildfly.clustering.session.SessionMetaData;
  * @author Paul Ferraro
  */
 public class CachedSessionManager<C> extends DecoratedSessionManager<C> {
-	static final Logger LOGGER = Logger.getLogger(CachedSessionManager.class);
+	static final System.Logger LOGGER = System.getLogger(CachedSessionManager.class.getName());
 
 	private final Cache<String, CompletionStage<CacheableSession<C>>> sessionCache;
 	private final BiFunction<String, Runnable, CompletionStage<CacheableSession<C>>> sessionCreator;
@@ -41,7 +40,7 @@ public class CachedSessionManager<C> extends DecoratedSessionManager<C> {
 					session.close();
 					return null;
 				} catch (Throwable e) {
-					LOGGER.warn(e.getLocalizedMessage(), e);
+					LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 				}
 			}
 			return session;
@@ -115,7 +114,7 @@ public class CachedSessionManager<C> extends DecoratedSessionManager<C> {
 				} catch (CancellationException e) {
 					// Ignore
 				} catch (Throwable e) {
-					LOGGER.warn(e.getLocalizedMessage(), e);
+					LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 				}
 			}
 		});

--- a/session/cache/src/main/java/org/wildfly/clustering/session/cache/CompositeSession.java
+++ b/session/cache/src/main/java/org/wildfly/clustering/session/cache/CompositeSession.java
@@ -6,7 +6,6 @@ package org.wildfly.clustering.session.cache;
 
 import java.util.function.Supplier;
 
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.CacheEntryRemover;
 import org.wildfly.clustering.server.util.Supplied;
 import org.wildfly.clustering.session.Session;
@@ -20,7 +19,7 @@ import org.wildfly.clustering.session.cache.metadata.InvalidatableSessionMetaDat
  * @author Paul Ferraro
  */
 public class CompositeSession<C> extends CompositeImmutableSession implements Session<C> {
-	private static final Logger LOGGER = Logger.getLogger(CompositeSession.class);
+	private static final System.Logger LOGGER = System.getLogger(CompositeSession.class.getName());
 
 	private final InvalidatableSessionMetaData metaData;
 	private final SessionAttributes attributes;
@@ -50,7 +49,7 @@ public class CompositeSession<C> extends CompositeImmutableSession implements Se
 	@Override
 	public void invalidate() {
 		if (this.metaData.invalidate()) {
-			LOGGER.debugf("Invalidating session %s", this.getId());
+			LOGGER.log(System.Logger.Level.DEBUG, "Invalidating session {0}", this.getId());
 			this.remover.remove(this.getId());
 		}
 	}
@@ -63,7 +62,7 @@ public class CompositeSession<C> extends CompositeImmutableSession implements Se
 	@Override
 	public void close() {
 		if (this.metaData.isValid()) {
-			LOGGER.tracef("Closing session %s", this.getId());
+			LOGGER.log(System.Logger.Level.TRACE, "Closing session {0}", this.getId());
 			this.attributes.close();
 			this.metaData.close();
 		}

--- a/session/cache/src/test/java/org/wildfly/clustering/session/cache/SessionManagerITCase.java
+++ b/session/cache/src/test/java/org/wildfly/clustering/session/cache/SessionManagerITCase.java
@@ -45,6 +45,7 @@ public abstract class SessionManagerITCase<P extends SessionManagerParameters> {
 	private static final String DEPLOYMENT_CONTEXT = "deployment";
 	private static final Supplier<AtomicReference<String>> SESSION_CONTEXT_FACTORY = AtomicReference::new;
 
+	private final System.Logger logger = System.getLogger(this.getClass().getName());
 	private final BiFunction<P, String, SessionManagerFactoryProvider<String>> factory;
 
 	protected SessionManagerITCase(BiFunction<P, String, SessionManagerFactoryProvider<String>> factory) {
@@ -220,7 +221,7 @@ public abstract class SessionManagerITCase<P extends SessionManagerParameters> {
 								Instant start = Instant.now();
 								ImmutableSession expiredSession = expiredSessions.poll(expirationDuration.getSeconds(), TimeUnit.SECONDS);
 								assertThat(expiredSession).as("No expiration event received within %s seconds", expirationDuration.getSeconds()).isNotNull();
-								System.out.println(String.format("Received expiration event for %s after %s", expiredSession.getId(), Duration.between(start, Instant.now())));
+								this.logger.log(System.Logger.Level.INFO, "Received expiration event for {0} after {1}", expiredSession.getId(), Duration.between(start, Instant.now()));
 								assertThat(sessionId).isEqualTo(expiredSession.getId());
 								assertThat(expiredSession.isValid()).isFalse();
 								assertThat(expiredSession.getMetaData().isNew()).isFalse();

--- a/session/cache/src/test/java/org/wildfly/clustering/session/cache/SessionManagerITCase.java
+++ b/session/cache/src/test/java/org/wildfly/clustering/session/cache/SessionManagerITCase.java
@@ -5,17 +5,21 @@
 
 package org.wildfly.clustering.session.cache;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -27,7 +31,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.wildfly.clustering.cache.batch.Batch;
-import org.wildfly.clustering.function.BiConsumer;
+import org.wildfly.clustering.context.DefaultThreadFactory;
 import org.wildfly.clustering.session.ImmutableSession;
 import org.wildfly.clustering.session.Session;
 import org.wildfly.clustering.session.SessionManager;
@@ -47,6 +51,7 @@ public abstract class SessionManagerITCase<P extends SessionManagerParameters> {
 
 	private final System.Logger logger = System.getLogger(this.getClass().getName());
 	private final BiFunction<P, String, SessionManagerFactoryProvider<String>> factory;
+	private final String threadGroupName = this.getClass().getSimpleName();
 
 	protected SessionManagerITCase(BiFunction<P, String, SessionManagerFactoryProvider<String>> factory) {
 		this.factory = factory;
@@ -120,11 +125,10 @@ public abstract class SessionManagerITCase<P extends SessionManagerParameters> {
 
 							this.createSession(manager1, sessionId, Map.of("value", value));
 
-							Instant start = Instant.now();
+							List<Runnable> tasks = new ArrayList<>(threads);
 							// Trigger a number of concurrent sequences of requests for the same session
-							CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
 							for (int i = 0; i < threads; ++i) {
-								future = future.thenAcceptBoth(CompletableFuture.runAsync(() -> {
+								tasks.add(() -> {
 									for (int j = 0; j < requests; ++j) {
 										this.requestSession(manager1, sessionId, session -> {
 											AtomicInteger v = (AtomicInteger) session.getAttributes().get("value");
@@ -132,38 +136,52 @@ public abstract class SessionManagerITCase<P extends SessionManagerParameters> {
 											v.incrementAndGet();
 										});
 									}
-								}), BiConsumer.empty());
+								});
 							}
-							future.join();
-							Instant stop = Instant.now();
-							Duration concurrentDuration = Duration.between(start, stop);
-
-							// Verify integrity of value on other manager
-							this.requestSession(manager2, sessionId, session -> {
-								assertThat((AtomicInteger) session.getAttributes().get("value")).hasValue(threads * requests);
-							});
-
-							start = Instant.now();
-							// Trigger sequences of the same number of requests for the same session
-							for (int i = 0; i < threads; ++i) {
-								for (int j = 0; j < requests; ++j) {
-									this.requestSession(manager1, sessionId, session -> {
-										AtomicInteger v = (AtomicInteger) session.getAttributes().get("value");
-										assertThat(v).isNotNull();
-										v.incrementAndGet();
-									});
+							List<Future<?>> futures = new ArrayList<>(threads);
+							ExecutorService executor = Executors.newFixedThreadPool(threads, new DefaultThreadFactory(new ThreadGroup(this.threadGroupName), Thread.currentThread().getContextClassLoader()));
+							try {
+								Instant start = Instant.now();
+								for (Runnable task : tasks) {
+									futures.add(executor.submit(task));
 								}
+								for (Future<?> future : futures) {
+									future.get();
+								}
+								Instant stop = Instant.now();
+								Duration concurrentDuration = Duration.between(start, stop);
+								this.logger.log(System.Logger.Level.INFO, "{0} concurrent requests completed in {1}", threads * requests, concurrentDuration);
+
+								// Verify integrity of value on other manager
+								this.requestSession(manager2, sessionId, session -> {
+									assertThat((AtomicInteger) session.getAttributes().get("value")).hasValue(threads * requests);
+								});
+
+								start = Instant.now();
+								// Trigger sequences of the same number of requests for the same session
+								for (int i = 0; i < threads; ++i) {
+									for (int j = 0; j < requests; ++j) {
+										this.requestSession(manager1, sessionId, session -> {
+											AtomicInteger v = (AtomicInteger) session.getAttributes().get("value");
+											assertThat(v).isNotNull();
+											v.incrementAndGet();
+										});
+									}
+								}
+								stop = Instant.now();
+								Duration serialDuration = Duration.between(start, stop);
+								this.logger.log(System.Logger.Level.INFO, "{0} serial requests completed in {1}", threads * requests, serialDuration);
+
+								// Verify integrity of value on other manager
+								this.requestSession(manager2, sessionId, session -> {
+									assertThat((AtomicInteger) session.getAttributes().get("value")).hasValue(threads * requests * 2);
+								});
+
+								// Ensure that concurrent requests complete faster than same number of serial requests
+								assertThat(concurrentDuration).isLessThan(serialDuration);
+							} finally {
+								executor.shutdown();
 							}
-							stop = Instant.now();
-							Duration serialDuration = Duration.between(start, stop);
-
-							// Verify integrity of value on other manager
-							this.requestSession(manager2, sessionId, session -> {
-								assertThat((AtomicInteger) session.getAttributes().get("value")).hasValue(threads * requests * 2);
-							});
-
-							// Ensure that concurrent requests complete faster than same number of serial requests
-							assertThat(concurrentDuration).isLessThan(serialDuration);
 
 							this.invalidateSession(manager2, sessionId);
 						} finally {
@@ -304,7 +322,7 @@ public abstract class SessionManagerITCase<P extends SessionManagerParameters> {
 					assertThat(metaData.isNew()).isFalse();
 					// Skip these assertions during concurrent session access
 					// We would otherwise require memory synchronization to validate
-					if (!(Thread.currentThread() instanceof ForkJoinWorkerThread)) {
+					if (!Thread.currentThread().getThreadGroup().getName().equals(this.threadGroupName)) {
 						// Validate last-access times are within precision bounds
 						assertThat(Duration.between(metaData.getLastAccessStartTime(), start).getSeconds()).isEqualTo(0);
 						assertThat(Duration.between(metaData.getLastAccessStartTime(), start).truncatedTo(ChronoUnit.MILLIS).getNano()).isEqualTo(0);

--- a/session/infinispan/embedded/src/main/java/org/wildfly/clustering/session/infinispan/embedded/ExpiredSessionRemover.java
+++ b/session/infinispan/embedded/src/main/java/org/wildfly/clustering/session/infinispan/embedded/ExpiredSessionRemover.java
@@ -11,7 +11,6 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.server.Registrar;
 import org.wildfly.clustering.server.Registration;
 import org.wildfly.clustering.session.ImmutableSession;
@@ -27,7 +26,7 @@ import org.wildfly.clustering.session.cache.SessionFactory;
  * @author Paul Ferraro
  */
 public class ExpiredSessionRemover<SC, MV, AV, LC> implements Predicate<String>, Registrar<Consumer<ImmutableSession>> {
-	private static final Logger LOGGER = Logger.getLogger(ExpiredSessionRemover.class);
+	private static final System.Logger LOGGER = System.getLogger(ExpiredSessionRemover.class.getName());
 
 	private final SessionFactory<SC, MV, AV, LC> factory;
 	private final Collection<Consumer<ImmutableSession>> listeners = new CopyOnWriteArraySet<>();
@@ -46,7 +45,7 @@ public class ExpiredSessionRemover<SC, MV, AV, LC> implements Predicate<String>,
 				if (attributesValue != null) {
 					Map<String, Object> attributes = this.factory.getAttributesFactory().createImmutableSessionAttributes(id, attributesValue);
 					ImmutableSession session = this.factory.createImmutableSession(id, metaData, attributes);
-					LOGGER.tracef("Session %s has expired.", id);
+					LOGGER.log(System.Logger.Level.TRACE, "Session {0} has expired.", id);
 					for (Consumer<ImmutableSession> listener : this.listeners) {
 						listener.accept(session);
 					}
@@ -58,9 +57,9 @@ public class ExpiredSessionRemover<SC, MV, AV, LC> implements Predicate<String>,
 					return false;
 				}
 			}
-			LOGGER.tracef("Session %s is not yet expired.", id);
+			LOGGER.log(System.Logger.Level.TRACE, "Session {0} is not yet expired.", id);
 		} else {
-			LOGGER.tracef("Session %s was not found or is currently in use.", id);
+			LOGGER.log(System.Logger.Level.TRACE, "Session {0} was not found or is currently in use.", id);
 		}
 		return false;
 	}

--- a/session/infinispan/embedded/src/main/java/org/wildfly/clustering/session/infinispan/embedded/SessionExpirationScheduler.java
+++ b/session/infinispan/embedded/src/main/java/org/wildfly/clustering/session/infinispan/embedded/SessionExpirationScheduler.java
@@ -13,7 +13,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.Key;
 import org.wildfly.clustering.cache.batch.Batch;
 import org.wildfly.clustering.context.DefaultThreadFactory;
@@ -33,7 +32,7 @@ import org.wildfly.clustering.session.cache.metadata.ImmutableSessionMetaDataFac
  * @param <V> the cache value type
  */
 public class SessionExpirationScheduler<K extends Key<String>, V> extends AbstractCacheEntryScheduler<String, K, V, ExpirationMetaData> {
-	private static final Logger LOGGER = Logger.getLogger(SessionExpirationScheduler.class);
+	private static final System.Logger LOGGER = System.getLogger(SessionExpirationScheduler.class.getName());
 	@SuppressWarnings("removal")
 	private static final ThreadFactory THREAD_FACTORY = new DefaultThreadFactory(SessionExpirationScheduler.class, AccessController.doPrivileged(new PrivilegedAction<>() {
 		@Override
@@ -108,7 +107,7 @@ public class SessionExpirationScheduler<K extends Key<String>, V> extends Abstra
 
 		@Override
 		public boolean test(String id) {
-			LOGGER.debugf("Expiring session %s", id);
+			LOGGER.log(System.Logger.Level.DEBUG, "Expiring session {0}", id);
 			try (Batch batch = this.batchFactory.get()) {
 				try {
 					return this.remover.test(id);
@@ -117,7 +116,7 @@ public class SessionExpirationScheduler<K extends Key<String>, V> extends Abstra
 					throw e;
 				}
 			} catch (RuntimeException e) {
-				LOGGER.warnf(e, id.toString());
+				LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 				return false;
 			}
 		}

--- a/session/infinispan/embedded/src/main/java/org/wildfly/clustering/session/infinispan/embedded/attributes/CoarseSessionAttributesFactory.java
+++ b/session/infinispan/embedded/src/main/java/org/wildfly/clustering/session/infinispan/embedded/attributes/CoarseSessionAttributesFactory.java
@@ -14,7 +14,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 import org.infinispan.Cache;
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.CacheEntryMutator;
 import org.wildfly.clustering.cache.CacheEntryMutatorFactory;
 import org.wildfly.clustering.cache.CacheProperties;
@@ -48,7 +47,7 @@ import org.wildfly.clustering.session.infinispan.embedded.metadata.SessionMetaDa
  * @author Paul Ferraro
  */
 public class CoarseSessionAttributesFactory<C, V> implements SessionAttributesFactory<C, Map<String, Object>> {
-	private static final Logger LOGGER = Logger.getLogger(CoarseSessionAttributesFactory.class);
+	private static final System.Logger LOGGER = System.getLogger(CoarseSessionAttributesFactory.class.getName());
 
 	private final Cache<SessionAttributesKey, V> cache;
 	private final Cache<SessionAttributesKey, V> writeCache;
@@ -103,7 +102,7 @@ public class CoarseSessionAttributesFactory<C, V> implements SessionAttributesFa
 	@Override
 	public CompletionStage<Map<String, Object>> findValueAsync(String id) {
 		return this.getValueAsync(id).exceptionally(e -> {
-			LOGGER.warn(e.getLocalizedMessage(), e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 			this.removeAsync(id);
 			return null;
 		});
@@ -174,7 +173,7 @@ public class CoarseSessionAttributesFactory<C, V> implements SessionAttributesFa
 				notification.accept(notifier, attributeValue);
 			}
 		} catch (IOException e) {
-			LOGGER.warn(id, e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 		}
 	}
 }

--- a/session/infinispan/embedded/src/main/java/org/wildfly/clustering/session/infinispan/embedded/attributes/FineSessionAttributesFactory.java
+++ b/session/infinispan/embedded/src/main/java/org/wildfly/clustering/session/infinispan/embedded/attributes/FineSessionAttributesFactory.java
@@ -15,7 +15,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 import org.infinispan.Cache;
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.CacheEntryMutatorFactory;
 import org.wildfly.clustering.cache.CacheProperties;
 import org.wildfly.clustering.cache.infinispan.embedded.EmbeddedCacheConfiguration;
@@ -48,7 +47,7 @@ import org.wildfly.clustering.session.infinispan.embedded.metadata.SessionMetaDa
  * @author Paul Ferraro
  */
 public class FineSessionAttributesFactory<C, V> implements SessionAttributesFactory<C, Map<String, Object>> {
-	private static final Logger LOGGER = Logger.getLogger(FineSessionAttributesFactory.class);
+	private static final System.Logger LOGGER = System.getLogger(FineSessionAttributesFactory.class.getName());
 
 	private final Cache<SessionAttributesKey, Map<String, V>> cache;
 	private final Cache<SessionAttributesKey, Map<String, V>> writeCache;
@@ -102,7 +101,7 @@ public class FineSessionAttributesFactory<C, V> implements SessionAttributesFact
 	@Override
 	public CompletionStage<Map<String, Object>> findValueAsync(String id) {
 		return this.getValueAsync(id).exceptionally(e -> {
-			LOGGER.warn(e.getLocalizedMessage(), e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 			this.removeAsync(id);
 			return null;
 		});
@@ -173,7 +172,7 @@ public class FineSessionAttributesFactory<C, V> implements SessionAttributesFact
 			try (SessionAttributeActivationNotifier notifier = this.detachedNotifierFactory.apply(id)) {
 				notification.accept(notifier, this.marshaller.read(entry.getValue()));
 			} catch (IOException e) {
-				LOGGER.warn(entry.getKey(), e);
+				LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 			}
 		}
 	}

--- a/session/infinispan/embedded/src/test/java/org/wildfly/clustering/session/infinispan/embedded/SessionExpirationSchedulerTestCase.java
+++ b/session/infinispan/embedded/src/test/java/org/wildfly/clustering/session/infinispan/embedded/SessionExpirationSchedulerTestCase.java
@@ -10,15 +10,14 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 import org.wildfly.clustering.cache.batch.Batch;
+import org.wildfly.clustering.function.Supplier;
 import org.wildfly.clustering.server.expiration.ExpirationMetaData;
 import org.wildfly.clustering.server.scheduler.Scheduler;
 import org.wildfly.clustering.session.ImmutableSessionMetaData;
 import org.wildfly.clustering.session.cache.metadata.ImmutableSessionMetaDataFactory;
-import org.wildfly.common.function.Functions;
 
 /**
  * Unit test for {@link SessionExpirationScheduler}.
@@ -61,7 +60,7 @@ public class SessionExpirationSchedulerTestCase {
 		doReturn(true).when(remover).test(expiringSessionId);
 		doReturn(false, true).when(remover).test(busySessionId);
 
-		try (Scheduler<String, ExpirationMetaData> scheduler = new SessionExpirationScheduler<>("test", Functions.constantSupplier(batch), metaDataFactory, remover, Duration.ZERO)) {
+		try (Scheduler<String, ExpirationMetaData> scheduler = new SessionExpirationScheduler<>("test", Supplier.of(batch), metaDataFactory, remover, Duration.ZERO)) {
 			scheduler.schedule(immortalSessionId, immortalSessionMetaData);
 			scheduler.schedule(canceledSessionId, canceledSessionMetaData);
 			scheduler.schedule(expiringSessionId, expiringSessionMetaData);

--- a/session/infinispan/remote/src/main/java/org/wildfly/clustering/session/infinispan/remote/HotRodSessionFactory.java
+++ b/session/infinispan/remote/src/main/java/org/wildfly/clustering/session/infinispan/remote/HotRodSessionFactory.java
@@ -18,7 +18,6 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryExpired;
 import org.infinispan.client.hotrod.annotation.ClientListener;
 import org.infinispan.client.hotrod.event.ClientCacheEntryExpiredEvent;
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.CacheEntryRemover;
 import org.wildfly.clustering.cache.infinispan.remote.RemoteCacheConfiguration;
 import org.wildfly.clustering.server.Registrar;
@@ -47,7 +46,7 @@ import org.wildfly.clustering.session.infinispan.remote.metadata.SessionCreation
  */
 @ClientListener
 public class HotRodSessionFactory<MC, AV, SC> extends CompositeSessionFactory<MC, SessionMetaDataEntry<SC>, AV, SC> implements Registrar<Consumer<ImmutableSession>> {
-	private static final Logger LOGGER = Logger.getLogger(HotRodSessionFactory.class);
+	private static final System.Logger LOGGER = System.getLogger(HotRodSessionFactory.class.getName());
 
 	private final RemoteCache<SessionCreationMetaDataKey, SessionCreationMetaDataEntry<SC>> creationMetaDataCache;
 	private final ImmutableSessionMetaDataFactory<SessionMetaDataEntry<SC>> metaDataFactory;
@@ -104,7 +103,7 @@ public class HotRodSessionFactory<MC, AV, SC> extends CompositeSessionFactory<MC
 						ImmutableSessionMetaData metaData = metaDataFactory.createImmutableSessionMetaData(id, new DefaultSessionMetaDataEntry<>(creationMetaDataEntry, accessMetaData));
 						Map<String, Object> attributes = attributesFactory.createImmutableSessionAttributes(id, attributesValue);
 						ImmutableSession session = HotRodSessionFactory.this.createImmutableSession(id, metaData, attributes);
-						LOGGER.tracef("Session %s has expired.", id);
+						LOGGER.log(System.Logger.Level.TRACE, "Session {0} has expired.", id);
 						for (Consumer<ImmutableSession> listener : listeners) {
 							listener.accept(session);
 						}

--- a/session/infinispan/remote/src/main/java/org/wildfly/clustering/session/infinispan/remote/HotRodSessionManager.java
+++ b/session/infinispan/remote/src/main/java/org/wildfly/clustering/session/infinispan/remote/HotRodSessionManager.java
@@ -7,10 +7,10 @@ package org.wildfly.clustering.session.infinispan.remote;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.wildfly.clustering.cache.batch.Batch;
+import org.wildfly.clustering.function.Consumer;
 import org.wildfly.clustering.server.Registrar;
 import org.wildfly.clustering.server.Registration;
 import org.wildfly.clustering.session.ImmutableSession;
@@ -18,7 +18,6 @@ import org.wildfly.clustering.session.SessionManager;
 import org.wildfly.clustering.session.SessionManagerConfiguration;
 import org.wildfly.clustering.session.cache.AbstractSessionManager;
 import org.wildfly.clustering.session.cache.SessionFactory;
-import org.wildfly.common.function.Functions;
 
 /**
  * Generic HotRod-based session manager implementation - independent of cache mapping strategy.
@@ -29,14 +28,14 @@ import org.wildfly.common.function.Functions;
  * @author Paul Ferraro
  */
 public class HotRodSessionManager<C, MV, AV, SC> extends AbstractSessionManager<C, MV, AV, SC> {
-	private final Registrar<Consumer<ImmutableSession>> expirationListenerRegistrar;
-	private final Consumer<ImmutableSession> expirationListener;
+	private final Registrar<java.util.function.Consumer<ImmutableSession>> expirationListenerRegistrar;
+	private final java.util.function.Consumer<ImmutableSession> expirationListener;
 	private final Supplier<Batch> batchFactory;
 
 	private AtomicReference<Registration> expirationListenerRegistration = new AtomicReference<>();
 
 	public HotRodSessionManager(Supplier<SessionManager<SC>> manager, SessionManagerConfiguration<C> configuration, SessionFactory<C, MV, AV, SC> factory, HotRodSessionManagerConfiguration hotrod) {
-		super(manager, configuration, hotrod, factory, Functions.discardingConsumer());
+		super(manager, configuration, hotrod, factory, Consumer.empty());
 		this.expirationListenerRegistrar = hotrod.getExpirationListenerRegistrar();
 		this.expirationListener = configuration.getExpirationListener();
 		this.batchFactory = hotrod.getBatchFactory();

--- a/session/infinispan/remote/src/main/java/org/wildfly/clustering/session/infinispan/remote/attributes/CoarseSessionAttributesFactory.java
+++ b/session/infinispan/remote/src/main/java/org/wildfly/clustering/session/infinispan/remote/attributes/CoarseSessionAttributesFactory.java
@@ -13,7 +13,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 
 import org.infinispan.client.hotrod.RemoteCache;
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.CacheEntryMutator;
 import org.wildfly.clustering.cache.CacheEntryMutatorFactory;
 import org.wildfly.clustering.cache.CacheProperties;
@@ -41,7 +40,7 @@ import org.wildfly.clustering.session.cache.attributes.coarse.SessionActivationN
  * @author Paul Ferraro
  */
 public class CoarseSessionAttributesFactory<C, V> implements SessionAttributesFactory<C, Map<String, Object>> {
-	private static final Logger LOGGER = Logger.getLogger(CoarseSessionAttributesFactory.class);
+	private static final System.Logger LOGGER = System.getLogger(CoarseSessionAttributesFactory.class.getName());
 
 	private final RemoteCache<SessionAttributesKey, V> readCache;
 	private final RemoteCache<SessionAttributesKey, V> writeCache;
@@ -75,7 +74,7 @@ public class CoarseSessionAttributesFactory<C, V> implements SessionAttributesFa
 	@Override
 	public CompletionStage<Map<String, Object>> findValueAsync(String id) {
 		return this.getValueAsync(id).exceptionally(e -> {
-			LOGGER.warn(e.getLocalizedMessage(), e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 			this.removeAsync(id);
 			return null;
 		});

--- a/session/infinispan/remote/src/main/java/org/wildfly/clustering/session/infinispan/remote/attributes/FineSessionAttributesFactory.java
+++ b/session/infinispan/remote/src/main/java/org/wildfly/clustering/session/infinispan/remote/attributes/FineSessionAttributesFactory.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 
 import org.infinispan.client.hotrod.RemoteCache;
-import org.jboss.logging.Logger;
 import org.wildfly.clustering.cache.CacheEntryMutatorFactory;
 import org.wildfly.clustering.cache.CacheProperties;
 import org.wildfly.clustering.cache.infinispan.remote.RemoteCacheConfiguration;
@@ -42,7 +41,7 @@ import org.wildfly.clustering.session.cache.attributes.fine.SessionAttributeMapC
  * @author Paul Ferraro
  */
 public class FineSessionAttributesFactory<C, V> implements SessionAttributesFactory<C, Map<String, Object>> {
-	private static final Logger LOGGER = Logger.getLogger(FineSessionAttributesFactory.class);
+	private static final System.Logger LOGGER = System.getLogger(FineSessionAttributesFactory.class.getName());
 
 	private final RemoteCache<SessionAttributesKey, Map<String, V>> readCache;
 	private final RemoteCache<SessionAttributesKey, Map<String, V>> writeCache;
@@ -75,7 +74,7 @@ public class FineSessionAttributesFactory<C, V> implements SessionAttributesFact
 	@Override
 	public CompletionStage<Map<String, Object>> findValueAsync(String id) {
 		return this.getValueAsync(id).exceptionally(e -> {
-			LOGGER.warn(e.getLocalizedMessage(), e);
+			LOGGER.log(System.Logger.Level.WARNING, e.getLocalizedMessage(), e);
 			this.purgeAsync(id);
 			return null;
 		});


### PR DESCRIPTION
These are getting increasingly difficult to reconcile dependency versions with multiple downstream consumers.
wildfly-common is quickly becoming obsolete - and our jboss-logging debug/trace usage can be easily migrated to System.Logger.