### PR TITLE
Revert back to TCCL for listener thread context

### DIFF
--- a/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/provider/CacheServiceProviderRegistrar.java
+++ b/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/provider/CacheServiceProviderRegistrar.java
@@ -132,7 +132,7 @@ public class CacheServiceProviderRegistrar<T> implements CacheContainerServicePr
 		ClassLoader loader = AccessController.doPrivileged(new PrivilegedAction<>() {
 			@Override
 			public ClassLoader run() {
-				return listener.getClass().getClassLoader();
+				return Thread.currentThread().getContextClassLoader();
 			}
 		});
 		@SuppressWarnings("removal")


### PR DESCRIPTION
... since listener implementation may be a container decorator.